### PR TITLE
Improve German translation

### DIFF
--- a/even-distribution/even-distribution_0.2.7/locale/de/even-distribution.cfg
+++ b/even-distribution/even-distribution_0.2.7/locale/de/even-distribution.cfg
@@ -10,14 +10,14 @@ drop-trash-to-chests=Verteile Abfall auf Truhen
 ignored-entities=Ignorierte Bauten
 
 [mod-setting-description]
-distribution-delay=Die Zeit in Sekunden die gewartet werden soll, bis die Gegenstände gleichmäßig auf mehrere Gebäude verteilt werden.
-take-from-car=Wenn aktiviert, werden Gegenstände aus dem Auto, das der Spieler gerade fährt, in die gleichmäßige Verteilung miteinbezogen.
-max-inventory-cleanup-drop-range=Zur Verwendung mit Inventar Bereinigungs-hotkey (SHIFT + C)!\n\nMaximale Verteilungsreichweite. Eigentliche Reichweite basiert auf der Reichweite des Charakters. Hohe Werte können die Performance beeinflussen.
-inventory-cleanup-custom-trash=Zur Verwendung mit Inventar Bereinigungs-hotkey (SHIFT + C)!\n\nZusätzliche Liste mit Müll-Gegenständen. Der Hotkey verteilt überschüssige Müll-Gegenstände gleichmäßig auf Maschinen in der Nähe. Überschrieben durch die Abfall-Logistikplätze.\n\n Gegenstandsnamen mit der gewünschten Anzahl die im Inventar behalten werden soll (getrennt durch Leerzeichen).
-early-autotrash-research=Zur Verwendung mit Inventar Bereinigungs-hotkey (SHIFT + C)!\n\nErforsche die Abfall-Logistikplätze früher um einfacher Abfall auszuwählen. Der Hotkey verteilt überschüssige Müll-Gegenstände gleichmäßig auf Maschinen in der Nähe.
-cleanup-logistic-request-overflow=Zur Verwendung mit Inventar Bereinigungs-hotkey (SHIFT + C)!\n\nÜberschüssige Logistikanforderungen werden als Abfall angesehen. Der Hotkey verteilt überschüssige Müll-Gegenstände gleichmäßig auf Maschinen in der Nähe.
-immediately-start-crafting=Wenn aktiviert, werden Crafting-Maschinen sofort mit dem Craften beginnen also erst auf die Verteilung zu warten.
-drop-trash-to-chests=Zur Verwendung mit Inventar Bereinigungs-hotkey (SHIFT + C)!\n\nÜberschüssiger Abfall wird auch auf Truhen in der Nähe, die den Gegenstand bereits beinhalten, verteilt. (Dies gilt nicht für Anforderungskisten)
+distribution-delay=Die Zeit in Sekunden, die gewartet werden soll, bis die Gegenstände gleichmäßig auf mehrere Gebäude verteilt werden.
+take-from-car=Wenn aktiviert, werden Gegenstände aus dem Fahrzeug, das der Spieler gerade fährt, in die gleichmäßige Verteilung miteinbezogen.
+max-inventory-cleanup-drop-range=Zur Verwendung mit Inventar Bereinigungs-Hotkey (SHIFT + C)!\n\nMaximale Verteilungsreichweite. Eigentliche Reichweite basiert auf der Reichweite des Charakters. Hohe Werte können die Performance beeinflussen.
+inventory-cleanup-custom-trash=Zur Verwendung mit Inventar Bereinigungs-Hotkey (SHIFT + C)!\n\nZusätzliche Liste mit Müll-Gegenständen. Der Hotkey verteilt überschüssige Müll-Gegenstände gleichmäßig auf Maschinen in der Nähe. Überschrieben durch die Abfall-Logistikplätze.\n\n Gegenstandsnamen mit der gewünschten Anzahl, die im Inventar behalten werden soll (getrennt durch Leerzeichen).
+early-autotrash-research=Zur Verwendung mit Inventar Bereinigungs-Hotkey (SHIFT + C)!\n\nErforsche die Abfall-Logistikplätze früher um einfacher Abfall auszuwählen. Der Hotkey verteilt überschüssige Müll-Gegenstände gleichmäßig auf Maschinen in der Nähe.
+cleanup-logistic-request-overflow=Zur Verwendung mit Inventar Bereinigungs-Hotkey (SHIFT + C)!\n\nÜberschüssige Logistikanforderungen werden als Abfall angesehen. Der Hotkey verteilt überschüssige Müll-Gegenstände gleichmäßig auf Maschinen in der Nähe.
+immediately-start-crafting=Wenn aktiviert, werden Crafting-Maschinen sofort mit dem Craften beginnen anstatt erst auf die Verteilung zu warten.
+drop-trash-to-chests=Zur Verwendung mit Inventar Bereinigungs-Hotkey (SHIFT + C)!\n\nÜberschüssiger Abfall wird auch auf Truhen in der Nähe, die den Gegenstand bereits beinhalten, verteilt. (Dies gilt nicht für Anforderungskisten)
 ignored-entities=Ziele die bei der Verteilung ignoriert werden.\n\nInterne Namen getrennt durch Leerzeichen.\nBeispiel: "steel-furnace iron-chest"
 
 [controls]


### PR DESCRIPTION
Nice mod.

One sentence was wrongly translated.  (`and` vs `instead of`)
Otherwise only minor improvements.
