### PR TITLE
Update for 0.18.22 compatibility

### DIFF
--- a/data.lua
+++ b/data.lua
@@ -5,7 +5,7 @@ data:extend{
 		type = "custom-input",
 		name = "inventory-cleanup",
 		key_sequence = "SHIFT + C",
-		consuming = "all"
+		consuming = "game-only"
 	}
 }
 


### PR DESCRIPTION
Consuming type of all was deprecated in 0.15.24 and has been fully removed in current experimental version of 0.18.22