### PR TITLE
Use 2.1's new defines.inventory.crafter_input

### DIFF
--- a/info.json
+++ b/info.json
@@ -1,11 +1,11 @@
 {
   "name": "even-distribution",
-  "version": "2.0.2",
-  "factorio_version": "2.0",
+  "version": "2.1.0",
+  "factorio_version": "2.1",
   "title": "Even Distribution",
   "author": "321freddy",
   "contact": "https://forums.factorio.com/viewtopic.php?f=92&t=46278",
   "homepage": "",
   "description": "Modifies CTRL + Click Drag to evenly distribute the items over multiple buildings. \r\n\r\nAdds Inventory Cleanup hotkey (SHIFT+C) to evenly distribute uneeded items from your inventory into nearby machines.",
-  "dependencies": ["base >= 2.0.7"]
+  "dependencies": ["base >= 2.1.7"]
 }

--- a/scripts/helpers/LuaControl.lua
+++ b/scripts/helpers/LuaControl.lua
@@ -75,10 +75,10 @@ function control:inventory(name)
                (self.type == "rocket-silo" and self.get_inventory(defines.inventory.rocket_silo_rocket))
 
     elseif name == "input" then
-        return (self.type == "furnace" and self.get_inventory(defines.inventory.furnace_source)) or
-               (self.type == "assembling-machine" and self.get_inventory(defines.inventory.assembling_machine_input)) or
+        return (self.type == "furnace" and self.get_inventory(defines.inventory.crafter_input)) or
+               (self.type == "assembling-machine" and self.get_inventory(defines.inventory.crafter_input)) or
                (self.type == "lab" and self.get_inventory(defines.inventory.lab_input)) or
-               (self.type == "rocket-silo" and self.get_inventory(defines.inventory.assembling_machine_input))
+               (self.type == "rocket-silo" and self.get_inventory(defines.inventory.crafter_input))
     
     elseif name == "output" then
         return self.get_output_inventory()


### PR DESCRIPTION
From Factorio 2.1's patch notes:

* Removed defines.inventory.assembling_machine_input, furnace_source, and rocket_silo_input. Use defines.inventory.crafter_input instead.